### PR TITLE
fix(utils): handles Retry-After header as str value.

### DIFF
--- a/tests/services/test_validate_addresses.py
+++ b/tests/services/test_validate_addresses.py
@@ -3,11 +3,50 @@ import json
 import unittest
 import urllib.parse as urlparse
 
+import pytest
 import responses
 
 from shipengine.enums import BaseURL, Endpoints
+from shipengine.errors import ShipEngineError, RateLimitExceededError
 
 from ..util import stub_shipengine_instance, valid_commercial_address
+
+expected_response_body = [
+    {
+        "status": "verified",
+        "original_address": {
+            "name": "ShipEngine",
+            "phone": "1-123-123-1234",
+            "company_name": "None",
+            "address_line1": "3800 N Lamar Blvd",
+            "address_line2": "ste 220",
+            "address_line3": "None",
+            "city_locality": "Austin",
+            "state_province": "TX",
+            "postal_code": "78756",
+            "country_code": "US",
+            "address_residential_indicator": "unknown",
+        },
+        "matched_address": {
+            "name": "SHIPENGINE",
+            "phone": "1-123-123-1234",
+            "company_name": "None",
+            "address_line1": "3800 N LAMAR BLVD STE 220",
+            "address_line2": "",
+            "address_line3": "None",
+            "city_locality": "AUSTIN",
+            "state_province": "TX",
+            "postal_code": "78756-0003",
+            "country_code": "US",
+            "address_residential_indicator": "no",
+        },
+        "messages": [],
+    }
+]
+
+rate_limit_exceeded_response_body = {
+    "message": "API rate limit exceeded",
+}
 
 
 class TestValidateAddresses(unittest.TestCase):
@@ -23,40 +62,7 @@ class TestValidateAddresses(unittest.TestCase):
                 "url": urlparse.urljoin(
                     BaseURL.SHIPENGINE_RPC_URL.value, Endpoints.ADDRESSES_VALIDATE.value
                 ),
-                "body": json.dumps(
-                    [
-                        {
-                            "status": "verified",
-                            "original_address": {
-                                "name": "ShipEngine",
-                                "phone": "1-123-123-1234",
-                                "company_name": "None",
-                                "address_line1": "3800 N Lamar Blvd",
-                                "address_line2": "ste 220",
-                                "address_line3": "None",
-                                "city_locality": "Austin",
-                                "state_province": "TX",
-                                "postal_code": "78756",
-                                "country_code": "US",
-                                "address_residential_indicator": "unknown",
-                            },
-                            "matched_address": {
-                                "name": "SHIPENGINE",
-                                "phone": "1-123-123-1234",
-                                "company_name": "None",
-                                "address_line1": "3800 N LAMAR BLVD STE 220",
-                                "address_line2": "",
-                                "address_line3": "None",
-                                "city_locality": "AUSTIN",
-                                "state_province": "TX",
-                                "postal_code": "78756-0003",
-                                "country_code": "US",
-                                "address_residential_indicator": "no",
-                            },
-                            "messages": [],
-                        }
-                    ]
-                ),
+                "body": json.dumps(expected_response_body),
                 "status": 200,
                 "content_type": "application/json",
             }
@@ -65,3 +71,56 @@ class TestValidateAddresses(unittest.TestCase):
         shipengine = stub_shipengine_instance()
         result = shipengine.validate_addresses(valid_commercial_address())
         self.assertEqual(result[0]["status"], "verified")
+
+    @responses.activate
+    def test_validate_addresses_when_rate_limit_exceeded_and_invalid_retry_value(self) -> None:
+        """
+        Tests that the validate_addresses method handles unexpected Retry-After
+        header values upon the rate limit being exceeded.
+        """
+        responses.add(
+            **{
+                "method": responses.POST,
+                "url": urlparse.urljoin(
+                    BaseURL.SHIPENGINE_RPC_URL.value, Endpoints.ADDRESSES_VALIDATE.value
+                ),
+                "body": json.dumps(rate_limit_exceeded_response_body),
+                "status": 429,
+                "content_type": "application/json",
+                "headers": {
+                    "Retry-After": "10.1"
+                }
+            }
+        )
+
+        shipengine = stub_shipengine_instance()
+        with pytest.raises(ShipEngineError) as exc_info:
+            shipengine.validate_addresses(valid_commercial_address())
+        
+        self.assertEqual(exc_info.value.message, 'Unexpected Retry-After header value.')
+
+    @responses.activate
+    def test_validate_addresses_when_rate_limit_exceeded(self) -> None:
+        """
+        Tests that the validate_addresses method handles the rate limit being exceeded
+        with the appropriate error.
+        """
+        responses.add(
+            **{
+                "method": responses.POST,
+                "url": urlparse.urljoin(
+                    BaseURL.SHIPENGINE_RPC_URL.value, Endpoints.ADDRESSES_VALIDATE.value
+                ),
+                "body": json.dumps(rate_limit_exceeded_response_body),
+                "status": 429,
+                "content_type": "application/json",
+                "headers": {
+                    "Retry-After": "0",  # NOTE: we use 0 here so that the test doesn't block
+                    "x-shipengine-requestid": "56b2b0a3-8df5-4cfe-95f0-d7efefdda2ad"
+                }
+            }
+        )
+
+        shipengine = stub_shipengine_instance()
+        with pytest.raises(RateLimitExceededError):
+            shipengine.validate_addresses(valid_commercial_address())


### PR DESCRIPTION
We have an issue currently in our staging environment where the sdk is obfuscating the API rate limiting issue that we've run into.

The following is the error we're seeing.

```
TypeError: '>' not supported between instances of 'str' and 'int'
  File "rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "swap/transactions/views.py", line 125, in checkout
    obj.initialize_checkout(self.request.retailer)
  File "swap/transactions/models.py", line 623, in initialize_checkout
    if not self.get_shipping_address_for_participant(retailer).address_is_valid():
  File "swap/contacts/models.py", line 217, in address_is_valid
    return ShipmentApi.validate_shipping_address(self, save=save)
  File "swap/shipments/shipengine.py", line 110, in validate_shipping_address
    if return_value := self.validate_formatted_address(formatted_address):
  File "swap/shipments/shipengine.py", line 103, in validate_formatted_address
    return self.shipengine.validate_addresses([formatted_address])
  File "shipengine/shipengine.py", line 142, in validate_addresses
    return self.client.post(
  File "shipengine/http_client/client.py", line 61, in post
    return self._request_loop(
  File "shipengine/http_client/client.py", line 104, in _request_loop
    raise err
  File "shipengine/http_client/client.py", line 87, in _request_loop
    api_response = self._send_request(
  File "shipengine/http_client/client.py", line 145, in _send_request
    check_response_for_errors(
  File "shipengine/util/sdk_assertions.py", line 204, in check_response_for_errors
    if retry_after > config.timeout:
```
