### PR TITLE
feat!: drop Python 3.7-3.9 support, add Python 3.10-3.13 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,10 @@ classifiers = [
     "Natural Language :: English",
     "Intended Audience :: Developers",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
@@ -32,8 +33,8 @@ bump = true
 files = ["*.py", "*/__init__.py", "*/__version__.py", "*/version.py"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
-aiohttp = "^3.7.4"
+python = "^3.10"
+aiohttp = "^3.9.0"
 requests = "^2.25.1"
 python-dotenv = "^0.15.0"
 dataclasses-json = "^0.5.3"
@@ -41,11 +42,11 @@ fuuid = "^0.1.0"
 poetry-dynamic-versioning = "^0.13.0"
 
 [tool.poetry.dev-dependencies]
-pytest = ">=5.0"
+pytest = "^7.0.0"
 pytest-cov = "^2.11.1"
 pytest-mock = "^3.6.1"
-black = "^20.8b1"
-flake8 = "^3.8.4"
+black = "^22.0.0"
+flake8 = "^6.0.0"
 Sphinx = "^3.5.2"
 tox = "^3.23.0"
 coverage = "^5.5"
@@ -57,7 +58,7 @@ responses = "^0.13.3"
 
 [tool.black]
 line-length = 100
-target-verstion = ["py37"]
+target-version = ["py310"]
 safe = true
 
 [tool.isort]


### PR DESCRIPTION
## Summary

This PR updates the Python version support to align with the updated CI configuration and modern Python versions.

### Breaking Changes

**⚠️ BREAKING CHANGE**: Python 3.7, 3.8, and 3.9 are no longer supported. The minimum required Python version is now **3.10**.

### Changes Made

**pyproject.toml updates:**
- Updated `python` dependency from `^3.7` to `^3.10`
- Updated classifiers to list Python 3.10, 3.11, 3.12, 3.13 (removed 3.7, 3.8, 3.9)
- Updated `aiohttp` to `^3.9.0` for Python 3.10+ compatibility
- Updated dev dependencies:
  - `pytest` from `>=5.0` to `^7.0.0`
  - `black` from `^20.8b1` to `^22.0.0`
  - `flake8` from `^3.8.4` to `^6.0.0`
- Fixed typo: `target-verstion` → `target-version` in black config
- Updated black target-version from `py37` to `py310`

### Rationale

- Python 3.7, 3.8, and 3.9 have reached or are approaching end-of-life
- CI workflows (PR #38) now test against Python 3.10-3.13
- Package dependencies have been updated to versions compatible with Python 3.10+

### Release Impact

This PR uses a conventional commit with `feat!:` which will trigger **release-please** to:
- Create a **major version bump** (2.0.0)
- Generate appropriate CHANGELOG entries
- Create a release PR that, when merged, will automatically publish to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)