### PR TITLE
fix: correct typo in CD workflow (dependancies -> dependencies)

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: "3.12"
         if: ${{ steps.release.outputs.release_created }}
 
-      - name: Install dependancies
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry


### PR DESCRIPTION
## Summary

Fixes a typo in the CD workflow: `dependancies` → `dependencies`

## Purpose

This fix commit will trigger release-please to create a 2.0.1 release PR. When that PR is merged, it will properly trigger the CD workflow to publish version 2.0.1 to PyPI.

(The 2.0.0 release was created manually and didn't trigger the CD workflow since it expects releases created by release-please)

🤖 Generated with [Claude Code](https://claude.com/claude-code)