### PR TITLE
fix: remove unused python-dotenv dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1277,21 +1277,6 @@ pytest = ">=2.6.4"
 watchdog = ">=0.6.0"
 
 [[package]]
-name = "python-dotenv"
-version = "0.15.0"
-description = "Add .env support to your django/flask apps in development and deployments"
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "python-dotenv-0.15.0.tar.gz", hash = "sha256:587825ed60b1711daea4832cf37524dfd404325b7db5e25ebe88c495c9f807a0"},
-    {file = "python_dotenv-0.15.0-py2.py3-none-any.whl", hash = "sha256:0c8d1b80d1a1e91717ea7d526178e3882732420b03f08afea0406db6402e220e"},
-]
-
-[package.extras]
-cli = ["click (>=5.0)"]
-
-[[package]]
 name = "pytz"
 version = "2021.1"
 description = "World timezone definitions, modern and historical"
@@ -1956,4 +1941,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "64fd65e4d772fe43ab6ea05d9eb69792f5e0f7d399bf1c754d7afd9d6cc585b7"
+content-hash = "4d246f01f4e7877c4ab2f46dd21166b05f9aff23a0907987e708a171b44ad068"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ files = ["*.py", "*/__init__.py", "*/__version__.py", "*/version.py"]
 python = "^3.10"
 aiohttp = "^3.9.0"
 requests = "^2.25.1"
-python-dotenv = "^0.15.0"
 dataclasses-json = "^0.5.3"
 fuuid = "^0.1.0"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,6 @@ pytest>=7.0.0; python_version >= "3.6"
 pytest-cov==2.12.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 pytest-mock==3.6.1; python_version >= "3.6"
 pytest-watch==4.2.0
-python-dotenv==0.15.0
 pytz==2021.1; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.5"
 pyyaml>=6.0; python_full_version >= "3.6.1"
 regex==2021.8.3; python_version >= "3.6"


### PR DESCRIPTION
`python-dotenv` is declared as a runtime dependency in `pyproject.toml` but is never imported or used anywhere in the package. This removes it from `pyproject.toml`, `requirements.txt`, and regenerates `poetry.lock`.

Two motivations:

- My downstream project's Dependabot is hitting a version conflict since shipengine currently pins python-dotenv<0.16.0. Since the dependency isn't actually used, removing it entirely resolves the conflict.
- This `fix:` commit should give release-please a properly formatted conventional commit to parse, triggering a new release PR. The previous 2.1.0 bump never made it to PyPI because my merge commits didn't follow the Conventional Commits format, so release-please silently skipped them.