### PR TITLE
docs: fix grammar in README tracking method descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Methods
 - [get_rates_from_shipment](./docs/get_rates_from_shipment_example.md) - Fetch rates from shipment details to shop the best shipping rate for your package.
 - [list_carriers](./docs/list_carriers_example.md) - Lists the carrier accounts connected to your ShipEngine account.
 - [track_package_by_label_id](./docs/track_package_by_label_id_example.md) - Track a package by `label_id`, the preferred way to track shipments if you create shipping labels using ShipEngine. This method returns
-the all tracking events for a given shipment.
+all tracking events for a given shipment.
 - [track_package_by_carrier_code_and_tracking_number](./docs/track_package_by_carrier_code_and_tracking_number_example.md) - Track a package by `carrier_code` and `tracking_number`. This method returns
-the all tracking events for a given shipment.
+all tracking events for a given shipment.
 - [void_label_by_label_id](./docs/void_label_by_label_id_example.md) - Void a shipping label you created using ShipEngine by its `label_id`. This method returns an object that indicates the status of the void label request.
 - [list_labels_by_tracking_number](./docs/list_labels_by_tracking_number.md) - List the labels associated with the given tracking number.
 


### PR DESCRIPTION
Removes errant article "the" from two tracking method descriptions in README.md:

> "This method returns the all tracking events for a given shipment."
> → "This method returns all tracking events for a given shipment."

Also includes `Release-As: 2.1.1` footer to instruct release-please to target version 2.1.1 (previous attempt via empty commit on `chore/release-as-2.1.1` was a no-op because GitHub squash-merge drops commits with no file changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)